### PR TITLE
Add simple test apps for python, java, and scala

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,19 @@
+# spark-basic.py
+import sys
+import time
+import numpy
+
+from pyspark import SparkConf
+from pyspark import SparkContext
+
+conf = SparkConf()
+conf.setAppName('spark-basic')
+sc = SparkContext(conf=conf)
+
+def mod(x):
+    return (x, numpy.mod(x, 2))
+
+print('\n'.join(sys.path))
+rdd = sc.parallelize(range(1000000)).map(mod).take(30)
+print rdd
+time.sleep(60)

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,9 @@
+scalaHome := Some(file("/opt/scala"))
+scalaVersion := "2.11.8"
+
+name := "SparkPi"
+
+version := "0.1"
+unmanagedSourceDirectories in Compile := (scalaSource in Compile).value :: Nil
+
+libraryDependencies += "org.apache.spark" % "spark-sql_2.11" % "2.1.0" % "provided"

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,25 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.mycompany.app</groupId>
+  <artifactId>java-spark-pi</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>java-spark-pi</name>
+  <url>http://maven.apache.org</url>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_2.10</artifactId>
+      <version>2.0.0</version>
+      <type>jar</type>
+    </dependency>
+
+  </dependencies>
+</project>

--- a/src/main/java/com/mycompany/app/JavaSparkPi.java
+++ b/src/main/java/com/mycompany/app/JavaSparkPi.java
@@ -1,0 +1,60 @@
+/*
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// We need comment here to bump the commit hash
+package org.apache.spark.examples;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.api.java.function.Function2;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Computes an approximation to pi
+ * Usage: JavaSparkPi [slices]
+ */
+public final class JavaSparkPi {
+
+  public static void main(String[] args) throws Exception {
+    SparkConf sparkConf = new SparkConf().setAppName("JavaSparkPi");
+    JavaSparkContext jsc = new JavaSparkContext(sparkConf);
+
+    int slices = (args.length == 1) ? Integer.parseInt(args[0]) : 2;
+    int n = 100000 * slices;
+    List<Integer> l = new ArrayList<Integer>(n);
+    for (int i = 0; i < n; i++) {
+      l.add(i);
+    }
+
+    JavaRDD<Integer> dataSet = jsc.parallelize(l, slices);
+
+    int count = dataSet.map(new Function<Integer, Integer>() {
+      @Override
+      public Integer call(Integer integer) {
+        double x = Math.random() * 2 - 1;
+        double y = Math.random() * 2 - 1;
+        return (x * x + y * y < 1) ? 1 : 0;
+      }
+    }).reduce(new Function2<Integer, Integer, Integer>() {
+      @Override
+      public Integer call(Integer integer, Integer integer2) {
+        return integer + integer2;
+      }
+    });
+
+    System.out.println("Pi is rouuuughly " + 4.0 * count / n);
+
+    jsc.stop();
+  }
+}

--- a/src/main/scala/org/apache/spark/examples/SparkPi.scala
+++ b/src/main/scala/org/apache/spark/examples/SparkPi.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// scalastyle:off println
+package org.apache.spark.examples
+
+import scala.math.random
+
+import org.apache.spark.sql.SparkSession
+
+/** Computes an approximation to pi */
+object SparkPi {
+  def main(args: Array[String]) {
+    val spark = SparkSession
+      .builder
+      .appName("Spark Pi")
+      .getOrCreate()
+    val slices = if (args.length > 0) args(0).toInt else 2
+    val n = math.min(100000L * slices, Int.MaxValue).toInt // avoid overflow
+    val count = spark.sparkContext.parallelize(1 until n, slices).map { i =>
+      val x = random * 2 - 1
+      val y = random * 2 - 1
+      if (x*x + y*y < 1) 1 else 0
+    }.reduce(_ + _)
+    println("Pi is roughly " + 4.0 * count / (n - 1))
+    spark.stop()
+  }
+}
+// scalastyle:on println


### PR DESCRIPTION
Co-locating these simple apps here will make them easy
to maintain and reference for integration tests. The sbt.build
file for scala has been set to ignore the java sources.