### PR TITLE
Disable maven jar plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,19 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <phase>never</phase>
+            <configuration>
+              <finalName>unwanted</finalName>
+              <classifier>unwanted</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <version>2.4</version>


### PR DESCRIPTION
This change will avoid run jar plugin and generate only an uberjar with all dependencies and the manifest file.