### PR TITLE
Change the package name of the java test app to match path

### DIFF
--- a/src/main/java/com/mycompany/app/JavaSparkPi.java
+++ b/src/main/java/com/mycompany/app/JavaSparkPi.java
@@ -9,7 +9,7 @@
  */
 
 // We need comment here to bump the commit hash
-package org.apache.spark.examples;
+package com.mycompany.app;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaRDD;


### PR DESCRIPTION
The plugin that generates the manifest file is expecting the
package name to match the path name, so make them match.